### PR TITLE
Comply with (Gemnasium) conventions for changelogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,17 @@
-### 1.0.0 / 2013-02-15
+# 1.0.0 / 2013-02-15
 
 * Add development mode, where `minibundle` block will copy each asset
   as-is to the destination directory
 * Clarify documentation
 * Increase test coverage
 
-### 0.2.0 / 2012-12-15
+# 0.2.0 / 2012-12-15
 
 * Escape the values of custom attributes given in `minibundle` block
 * Add semicolons between each JavaScript asset in bundling
 * Show error in page output if asset bundling command failed
 
-### 0.1.0 / 2012-12-07
+# 0.1.0 / 2012-12-07
 
 * Add `ministamp` tag and `minibundle` block for Jekyll
 * First release


### PR DESCRIPTION
Rename History.md to CHANGELOG.md and use first level headers for version numbers.

https://github.com/tech-angels/vandamme#changelogs-convention

I'm not going to use your otherwise promising gem unless the changelog is shown in its [Gemnasium page](https://gemnasium.com/gems/jekyll-minibundle)! ;-)
