### PR TITLE
If minifier_cmd fails, include output in fail msg

### DIFF
--- a/lib/jekyll/minibundle/asset_bundle.rb
+++ b/lib/jekyll/minibundle/asset_bundle.rb
@@ -36,7 +36,12 @@ Missing minification command for bundling #{@type} assets. Specify it in
           input.puts(';') if @type == :js
         end
       end
-      fail "Bundling #{@type} assets failed with exit status #{exit_status}, command: #{@minifier_cmd}" if exit_status != 0
+      if exit_status != 0
+        output = File.read(@temp_file.path)
+        chars_of_output = 5000
+        truncated_output = output[-chars_of_output..-1] || output
+        fail "Bundling #{@type} assets failed with exit status #{exit_status}, command: #{@minifier_cmd} Last #{chars_of_output} chars of output: #{truncated_output}"
+      end
       self
     end
 

--- a/test/unit/asset_bundle_test.rb
+++ b/test/unit/asset_bundle_test.rb
@@ -6,7 +6,14 @@ module Jekyll::Minibundle::Test
     def test_raise_exception_if_bundle_command_fails
       capture_io do
         err = assert_raises(RuntimeError) { make_bundle('read _ignore ; false') }
-        assert_equal 'Bundling js assets failed with exit status 1, command: read _ignore ; false', err.to_s
+        assert_equal 'Bundling js assets failed with exit status 1, command: read _ignore ; false Last 5000 chars of output: ', err.to_s
+      end
+    end
+
+    def test_include_output_if_command_fails
+      capture_io do
+        err = assert_raises(RuntimeError) { make_bundle('printf I_FAILED ; false') }
+        assert_equal 'Bundling js assets failed with exit status 1, command: printf I_FAILED ; false Last 5000 chars of output: I_FAILED', err.to_s
       end
     end
 


### PR DESCRIPTION
The output is likely to include helpful information.

In my case: Output before change:


`        Minibundle: Bundling js assets:
        Minibundle: js/main.js
  Liquid Exception: Bundling js assets failed with exit status 1, command: r.js -o baseUrl=js name=main out=stdout in index.html
`

Output after change, which contains information crucial to continue debugging the problem:

`        Minibundle: Bundling js assets:
        Minibundle: js/main.js
  Liquid Exception: Bundling js assets failed with exit status 1, command: r.js -o baseUrl=js name=main out=stdout output: Tracing dependencies for: main Uglifying file: main.build.js Error: TypeError: process.stdout.setEncoding is not a function at Object.config.out (/usr/local/lib/node_modules/requirejs/bin/r.js:31077:36) in index.html
`

Thanks for a nice plugin btw.