### PR TITLE
Allow for attributes without values

### DIFF
--- a/lib/jekyll/minibundle/asset_tag_markup.rb
+++ b/lib/jekyll/minibundle/asset_tag_markup.rb
@@ -20,7 +20,11 @@ module Jekyll::Minibundle
       end
 
       def make_attribute(name, value)
-        %{ #{name}="#{CGI.escape_html(value)}"}
+        unless value.nil?
+          %{ #{name}="#{CGI.escape_html(value)}"}
+        else
+          %{ #{name} }
+        end
       end
 
       def make_url(baseurl, path)


### PR DESCRIPTION
My markup was failing an HTML validation test, so I made this change so the async attribute could be added to the script element without a value.
